### PR TITLE
Added --inline-symbols option as a mode for no <symbol>/<use>

### DIFF
--- a/src/svgtiler.coffee
+++ b/src/svgtiler.coffee
@@ -2184,6 +2184,11 @@ class Render extends HasSettings
       node.removeAttribute 'data-width'
       height = node.getAttribute 'data-height'
       node.removeAttribute 'data-height'
+      
+      if @settings.inlineSymbols
+        # When inlining symbols, keep images as is
+        return true
+      
       # Transfer x/y/width/height to <use> element, for more re-usability.
       node.parentNode.replaceChild (use = doc.createElementNS SVGNS, 'use'),
         node


### PR DESCRIPTION
## Summary

This PR adds an option for no `<symbol> / <use>`

## Motivation

This is a solution to the following issue raised by Erik: https://github.com/edemaine/svgtiler/issues/111

## Test Plan

### Setup

- Tested on a Macbook with Apple Silicon.

### Tests

I tested this on tetris. First I tried without the inline symbol:

```
brew install inkscape
coffee Maketile.coffee
```

![image](https://github.com/user-attachments/assets/eb3ac7ba-b952-438f-950f-21cc1837ec3f)

Here is the [SVG gist](https://gist.github.com/jadidbourbaki/e5bb2aa1e12fcb1a410bb78366dec974).

Then I modified the Makefile.coffee script to use inline symbols, i.e. 

```
txt: ->
  svgtiler '--inline-symbols -f -P --bg black NES_level7.txt example.asc'
coffee: ->
  svgtiler '--inline-symbols -f -P NES_level7.coffee example.asc'
'': ->
  svgtiler 'txt coffee'
```

and ran it again to get

![image](https://github.com/user-attachments/assets/690aa894-566a-4e56-9d0d-b3500a32cc11)

Here is the [SVG gist](https://gist.github.com/jadidbourbaki/ee6a4e6f6b229cca8d341fad391a4dbf).

Confirmed that all use tags are replaced by inline images ✅ 

## Roll out and Monitoring

- I use svgtiler for my own research work so will be monitoring if this breaks.

- I can commit to providing support for and/or rolling back this feature for the next two weeks in case there are any initial breakages. 

## Notes to the reviewer

- This may not work in all cases (I think?) as the svgBBox implementation ignores symbols. However, this is safe to add as it essentially keeps the original program output the exact same unless we deliberately enable the optional --inline-symbols command line flag.
- I can iteratively add more extensive inline for exceptional cases and do more testing (add potential unit tests) in future PRs if this is task provides utility.